### PR TITLE
Added a PORT configuration option

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const app = express();
 
-const PORT = 8080;
+const PORT = process.env.PORT || 8080;
 const JS_DIR = 'js';
 const JS_MOUNT_PATH = '/js';
 const MODELS_DIR = 'models';


### PR DESCRIPTION
That way, anyone could run `PORT=1234 npm start` instead of closing other apps running on port 8080.
I was thinking of making it so that it uses whichever port is available but I think it may not be as necessary as this.