### PR TITLE
Adds a CD action using GH Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,29 @@
+name: GH Pages CD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧
+        run: |
+          npm ci
+        # npm run build (Needed when we use a transpiler/bundler)
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: public # The folder the action should deploy.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,14 +12,12 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
-        # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
         with:
           persist-credentials: false
 
       - name: Install and Build 🔧
         run: |
           npm ci
-        # npm run build (Needed when we use a transpiler/bundler)
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
<strike><h3>This action <em>wont work</em> until a <code>ACCESS_TOKEN</code> <u>secret</u> is set up!</h3></strike>

To do that, it will need to be set up in the [Settings/Secrets section](https://github.com/misterpeddy/hands-down/settings/secrets) (more info can be found [here](https://github.com/marketplace/actions/deploy-to-github-pages#configuration-)).

Closes #28 and #5 (where the CI was already done on https://github.com/misterpeddy/hands-down/commit/e1e8c495fd3ccbd7ac7aac6b8b3a757c208849e7).

It also only has one environment which would be the one pointing to `misterpeddy.github.io/hands-down`, and I'm unsure how GH Pages could satisfy the requirement:
> Should be able to set up staging and prod instances (not necessary at first)

If we want to change the domain name to say `www.hands-down.org`, we'll need to follow https://help.github.com/en/github/working-with-github-pages/about-custom-domains-and-github-pages.