### PR TITLE
Fixes CORS issue; Configures tf.js backend fallback

### DIFF
--- a/public/js/draw.js
+++ b/public/js/draw.js
@@ -4,7 +4,7 @@
  * in the provided context.
  */
 function drawPoints(ctx, points, r) {
-  if (points == undefined) return;
+  if (points === undefined) return;
 
   for (let i = 0; i < points.length; i += 1) {
     const x = points[i][0];
@@ -21,7 +21,7 @@ function drawPoints(ctx, points, r) {
  * next point until the final point is reached.
  */
 function drawPath(ctx, points) {
-  if (points == undefined) return;
+  if (points === undefined) return;
 
   const region = new Path2D();
   region.moveTo(points[0][0], points[0][1]);

--- a/public/js/draw.js
+++ b/public/js/draw.js
@@ -4,6 +4,8 @@
  * in the provided context.
  */
 function drawPoints(ctx, points, r) {
+  if (points == undefined) return;
+
   for (let i = 0; i < points.length; i += 1) {
     const x = points[i][0];
     const y = points[i][1];
@@ -19,6 +21,8 @@ function drawPoints(ctx, points, r) {
  * next point until the final point is reached.
  */
 function drawPath(ctx, points) {
+  if (points == undefined) return 0;
+
   const region = new Path2D();
   region.moveTo(points[0][0], points[0][1]);
   for (let i = 1; i < points.length; i += 1) {

--- a/public/js/draw.js
+++ b/public/js/draw.js
@@ -21,7 +21,7 @@ function drawPoints(ctx, points, r) {
  * next point until the final point is reached.
  */
 function drawPath(ctx, points) {
-  if (points == undefined) return 0;
+  if (points == undefined) return;
 
   const region = new Path2D();
   region.moveTo(points[0][0], points[0][1]);

--- a/public/js/models.js
+++ b/public/js/models.js
@@ -31,7 +31,7 @@ async function initializeModel() {
       break;
   }
 
-  if (i > BACKENDS.length || tf.getBackend() == undefined)
+  if (i == BACKENDS.length || tf.getBackend() == undefined)
     throw Error("No TensorFlow backend was successfully initialized.");
 
   function completeInit(models) {

--- a/public/js/models.js
+++ b/public/js/models.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-undef */
 
-const MODEL_FILENAME = "model.json";
-const MODEL_VERSION = "31-03-20-0";
-const REMOTE_MODEL_ROOT = "http://peddy-ai-models.storage.googleapis.com/hands-down";
-const LOCAL_MODEL_ROOT = "public/models";
+const MODEL_FILENAME = 'model.json';
+const MODEL_VERSION = '31-03-20-0';
+const REMOTE_MODEL_ROOT =
+  'http://peddy-ai-models.storage.googleapis.com/hands-down';
+const LOCAL_MODEL_ROOT = 'public/models';
 
 const REMOTE_MODEL_URL = `${REMOTE_MODEL_ROOT}/${MODEL_VERSION}/${MODEL_FILENAME}`;
 const LOCAL_MODEL_URL = `${LOCAL_MODEL_ROOT}/${MODEL_VERSION}/${MODEL_FILENAME}`;
@@ -24,15 +25,14 @@ let initialized;
  * and loads the frozen classifer into memory, all in parallel.
  */
 async function initializeModel() {
-
-  var i=0;
-  for (; i<BACKENDS.length; i++) {
-    if (await tf.setBackend(BACKENDS[i]))
-      break;
+  let i = 0;
+  for (; i < BACKENDS.length; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await tf.setBackend(BACKENDS[i])) break;
   }
 
-  if (i == BACKENDS.length || tf.getBackend() == undefined)
-    throw Error("No TensorFlow backend was successfully initialized.");
+  if (i === BACKENDS.length || tf.getBackend() === undefined)
+    throw Error('No TensorFlow backend was successfully initialized.');
 
   function completeInit(models) {
     if (models.length !== 3) {
@@ -59,7 +59,9 @@ async function initializeModel() {
 
   return Promise.all(modelPromises)
     .then((models) => completeInit(models))
-    .catch((err) => {throw Error("Model initialization unsuccessful: " + err)});
+    .catch((err) => {
+      throw Error(`Model initialization unsuccessful: ${err}`);
+    });
 }
 
 /*

--- a/public/js/models.js
+++ b/public/js/models.js
@@ -1,11 +1,12 @@
 /* eslint-disable no-undef */
 
+const MODEL_FILENAME = "model.json";
 const MODEL_VERSION = "31-03-20-0";
 const REMOTE_MODEL_ROOT = "http://peddy-ai-models.storage.googleapis.com/hands-down";
 const LOCAL_MODEL_ROOT = "public/models";
 
-const REMOTE_MODEL_URL = `${REMOTE_MODEL_ROOT}/${MODEL_VERSION}/model.json`;
-const LOCAL_MODEL_URL = `${LOCAL_MODEL_ROOT}/${MODEL_VERSION}/model.json`;
+const REMOTE_MODEL_URL = `${REMOTE_MODEL_ROOT}/${MODEL_VERSION}/${MODEL_FILENAME}`;
+const LOCAL_MODEL_URL = `${LOCAL_MODEL_ROOT}/${MODEL_VERSION}/${MODEL_FILENAME}`;
 
 const BACKENDS = ['webgl', 'wasm', 'cpu'];
 

--- a/tools/model-bucket-cors.json
+++ b/tools/model-bucket-cors.json
@@ -1,6 +1,6 @@
 [
     {
-      "origin": ["http://localhost:4000", "http://localhost:8080", "http://peddy.ai"],
+      "origin": ["*"],
       "responseHeader": ["Content-Type"],
       "method": ["GET", "HEAD", "DELETE"],
       "maxAgeSeconds": 3600

--- a/tools/model-bucket-cors.sh
+++ b/tools/model-bucket-cors.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# Usage: ./model-bucket-cors.sh <cors_config.json>
 GCS_BUCKET="gs://peddy-ai-models/"
 gsutil cors set $1 $GCS_BUCKET


### PR DESCRIPTION
A few discoveries:
* The reason WASM can't be used is handpose's use of conv2d kernels - we either have to implement the kernel ourselves or rely on webgl and cpu backends - this is a tricky issue because webgl is not supported on many machines, and cpu is far too slow.
* on some machines, webgl may be supported but disabled on chrome - go to chrome://flags/#enable-webgl2-compute-context to see if it's explicitly disabled 