### PR TITLE
Improves extrapolation

### DIFF
--- a/public/js/draw.js
+++ b/public/js/draw.js
@@ -69,16 +69,12 @@ function drawFrame(canvas, video, combinedFeatures) {
   let handPoints = null;
   if (combinedFeatures[1] !== null) {
     const handPoses = combinedFeatures[1];
-
-    // TODO Remove/merge this to the upper branch to avoid unnecessary complexity and computation
-    if (handPoses !== undefined && handPoses.length > 0) {
-      handPoints = handPoses[0].landmarks;
-      const handAnnotations = handPoses[0].annotations;
-      drawPoints(ctx, handPoints, 3);
-      Object.entries(handAnnotations).forEach(([, points]) =>
-        drawPath(ctx, points)
-      );
-    }
+    handPoints = handPoses[0].landmarks;
+    const handAnnotations = handPoses[0].annotations;
+    drawPoints(ctx, handPoints, 3);
+    Object.entries(handAnnotations).forEach(([, points]) =>
+      drawPath(ctx, points)
+    );
   }
 
   return [facePoints, handPoints];

--- a/public/js/draw.js
+++ b/public/js/draw.js
@@ -44,7 +44,6 @@ function drawFrame(canvas, video, combinedFeatures) {
   }
 
   const faceMeshes = combinedFeatures[0];
-  const handPoses = combinedFeatures[1];
   const ctx = canvas.getContext('2d');
 
   ctx.drawImage(
@@ -67,14 +66,19 @@ function drawFrame(canvas, video, combinedFeatures) {
   }
 
   // Render HandPose
-  let handPoints;
-  if (handPoses !== undefined && handPoses.length > 0) {
-    handPoints = handPoses[0].landmarks;
-    const handAnnotations = handPoses[0].annotations;
-    drawPoints(ctx, handPoints, 3);
-    Object.entries(handAnnotations).forEach(([, points]) =>
-      drawPath(ctx, points)
-    );
+  let handPoints = null;
+  if (combinedFeatures[1] !== null) {
+    const handPoses = combinedFeatures[1];
+
+    // TODO Remove/merge this to the upper branch to avoid unnecessary complexity and computation
+    if (handPoses !== undefined && handPoses.length > 0) {
+      handPoints = handPoses[0].landmarks;
+      const handAnnotations = handPoses[0].annotations;
+      drawPoints(ctx, handPoints, 3);
+      Object.entries(handAnnotations).forEach(([, points]) =>
+        drawPath(ctx, points)
+      );
+    }
   }
 
   return [facePoints, handPoints];

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -141,10 +141,6 @@ function processKeyPoints(combinedKeyPoints) {
 async function startEngine(canvas, video) {
   (function update() {
     computeCombinedKeyPoints(video)
-      .then((combinedFeatures) => {
-        const noHandFound = !combinedFeatures[1].length;
-        return noHandFound ? [combinedFeatures[0], null] : combinedFeatures;
-      })
       .then((combinedFeatures) => drawFrame(canvas, video, combinedFeatures))
       .then((combinedKeyPoints) => processKeyPoints(combinedKeyPoints))
       .then(() => requestAnimationFrame(update))

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -128,7 +128,7 @@ function processKeyPoints(combinedKeyPoints) {
       computeInference(facePoints, handPoints).then((inference) =>
         updateInferenceText(inference[0])
       );
-    } else document.getElementById('inference-txt').innerHTML = '0.00 %';
+    } else updateInferenceText(0);
   } else if (!state.isInDevMode) {
     document.getElementById('inference-txt').innerHTML = '- %';
   }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -123,8 +123,7 @@ function processKeyPoints(combinedKeyPoints) {
   }
 
   if (state.isInferenceOn) {
-    // TODO Look into merging/removing this condition to the line above to avoid unnecessary computations
-    if (facePoints !== undefined && handPoints !== null) {
+    if (handPoints !== null) {
       computeInference(facePoints, handPoints).then((inference) =>
         updateInferenceText(inference[0])
       );

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -123,11 +123,12 @@ function processKeyPoints(combinedKeyPoints) {
   }
 
   if (state.isInferenceOn) {
-    if (facePoints !== undefined && handPoints !== undefined) {
+    // TODO Look into merging/removing this condition to the line above to avoid unnecessary computations
+    if (facePoints !== undefined && handPoints !== null) {
       computeInference(facePoints, handPoints).then((inference) =>
         updateInferenceText(inference[0])
       );
-    }
+    } else document.getElementById('inference-txt').innerHTML = '0.00 %';
   } else if (!state.isInDevMode) {
     document.getElementById('inference-txt').innerHTML = '- %';
   }
@@ -141,6 +142,10 @@ function processKeyPoints(combinedKeyPoints) {
 async function startEngine(canvas, video) {
   (function update() {
     computeCombinedKeyPoints(video)
+      .then((combinedFeatures) => {
+        const noHandFound = !combinedFeatures[1].length;
+        return noHandFound ? [combinedFeatures[0], null] : combinedFeatures;
+      })
       .then((combinedFeatures) => drawFrame(canvas, video, combinedFeatures))
       .then((combinedKeyPoints) => processKeyPoints(combinedKeyPoints))
       .then(() => requestAnimationFrame(update))

--- a/public/js/models.js
+++ b/public/js/models.js
@@ -86,10 +86,13 @@ async function computeCombinedKeyPoints(video) {
     throw Error('Cannot compute key points for undefined video stream');
   }
 
-  return Promise.all([
+  const combinedFeatures = await Promise.all([
     faceMesh.estimateFaces(video),
     handPose.estimateHands(video),
   ]);
+
+  const noHandFound = !combinedFeatures[1].length;
+  return noHandFound ? [combinedFeatures[0], null] : combinedFeatures;
 }
 
 /*


### PR DESCRIPTION
Turns the `handPose` features into `null` as soon it sees there are none (i.e. the hands aren't visible). This way, as soon as no hands are visible, the hand-related computations (namely the inference computation) will be skipped (therefore increasing the _post-boot-up_ performance).

_Note: There are still some areas to look at tho (see my review comments on here and new TODO)_