### PR TITLE
Use VisibilityChange API

### DIFF
--- a/client/components/draw.js
+++ b/client/components/draw.js
@@ -38,12 +38,7 @@ const drawPath = (ctx, points) => {
  * the hand and face key points contained in combinedFeatures.
  * Returns the extracted combined keypoints.
  */
-const drawFrame = (canvas, video, combinedFeatures) => {
-  if (combinedFeatures === undefined) {
-    throw Error('Cannot draw frame with undefined features');
-  }
-
-  const faceMeshes = combinedFeatures[0];
+const drawFrame = (canvas, video, facePoints, handPoints, handAnnotations) => {
   const ctx = canvas.getContext('2d');
 
   ctx.drawImage(
@@ -59,25 +54,19 @@ const drawFrame = (canvas, video, combinedFeatures) => {
   );
 
   // Render FaceMesh
-  let facePoints;
-  if (faceMeshes !== undefined && faceMeshes.length > 0) {
-    facePoints = faceMeshes[0].scaledMesh;
+  if (facePoints) {
     drawPoints(ctx, facePoints, 1);
   }
-
   // Render HandPose
-  let handPoints = null;
-  if (combinedFeatures[1] !== null) {
-    const handPoses = combinedFeatures[1];
-    handPoints = handPoses[0].landmarks;
-    const handAnnotations = handPoses[0].annotations;
+  // let handPoints = null;
+  if (handPoints) {
     drawPoints(ctx, handPoints, 3);
+  }
+  if (handAnnotations) {
     Object.entries(handAnnotations).forEach(([, points]) =>
       drawPath(ctx, points)
     );
   }
-
-  return [facePoints, handPoints];
 };
 
 export default drawFrame;

--- a/client/main.js
+++ b/client/main.js
@@ -203,19 +203,18 @@ const initialize = async () => Promise.all([initializeModel(state), initDom()]);
  * Also responsible for the stopping the previous timer.
  */
 const handleVisibilityChange = () => {
-  if (document.visibilityState === 'hidden') {
-    if (state.timerId) {
+  state.isActiveTab = document.visibilityState === 'visible';
+  if (!state.isActiveTab) {
+    if (!state.timerId) {
       cancelAnimationFrame(state.timerId);
     }
-    state.isActiveTab = false;
     state.canvas.style.display = 'none';
     state.timerId = setInterval(computeFrame, FRAMES_PER_SECOND);
   } else {
-    if (state.timerId) {
-      clearTimeout(state.timerId);
-    }
     state.canvas.style.display = 'inline-block';
-    state.isActiveTab = true;
+    if (state.timerId) {
+      clearInterval(state.timerId);
+    }
     computeFrame();
   }
 };


### PR DESCRIPTION
After noticing the application doesn't make inferences when the tab isn't visible (i.e. on a different tab, screen on mac, etc). This was because `requestAnimationFrame` does not work on a background time and the timer doesn't tick. Taking @Berkmann18's advice, I have looked at the Page Visibility API and have the functionality to switch to `setTimeout` on an inactive tab. 

We now also don't do any drawings on the canvas if the tab isn't visible, which should hopefully somewhat make up for the performance drop from switching to `setTimeout`