### PR TITLE
Adds the RollingVersions action

### DIFF
--- a/.github/workflows/rollingversions.yml
+++ b/.github/workflows/rollingversions.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  repository_dispatch:
+    types: [rollingversions_publish_approved]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm i
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+        registry-url: 'https://npm.pkg.github.com' #'https://registry.npmjs.org'
+    - run: npm i
+    - run: npx rollingversions publish
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This WON'T work until [it's installed](https://github.com/apps/rollingversions/installations/new) and the NPM token set (even if the package is deployed on the [GH
package registry](https://github.com/features/packages)).