### PR TITLE
Adds seperate import for WebGL backend

### DIFF
--- a/public/dev.html
+++ b/public/dev.html
@@ -183,6 +183,12 @@
       src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm/dist/tf-backend-wasm.min.js"
     ></script>
 
+    <!-- Load WebGL backend for tf.js !-->
+    <script
+      crossorigin="anonymous"
+      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl"
+    ></script>
+
     <!-- Load three.js -->
     <script
       crossorigin="anonymous"

--- a/public/dev.html
+++ b/public/dev.html
@@ -112,7 +112,8 @@
       </div>
       <div class="row">
         <div class="one column"></div>
-        <div class="canvas-wrapper">
+        <div id="loader"></div>
+        <div style="display: none;" class="canvas-wrapper">
           <video id="video"></video>
           <canvas id="output"></canvas>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -187,6 +187,12 @@
       src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm/dist/tf-backend-wasm.min.js"
     ></script>
 
+    <!-- Load WebGL backend for tf.js !-->
+    <script
+      crossorigin="anonymous"
+      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl"
+    ></script>
+
     <!-- Load three.js -->
     <script
       crossorigin="anonymous"


### PR DESCRIPTION
According to https://github.com/tensorflow/tfjs/issues/3368 `WebGL` requires its own import now as it's not a part of `core` js anymore. 

Have added the new script tags both in `index.html` and `dev.html` 