### PR TITLE
Add versions tags to TF imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Help slow the spread of COVID-19 by discouraging people from touching their face while sitting in front of a computer.
 
+[Check it out here!](https://handsdown.dev/)
+
 ## Design
 
 We break down the problem of inferring whether the subject is touching their face into 2 parts:

--- a/public/dev.html
+++ b/public/dev.html
@@ -161,11 +161,11 @@
     <!-- Load tf.js libraries !-->
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core"
+      src="https://unpkg.com/@tensorflow/tfjs-core@2.1.0/dist/tf-core.js"
     ></script>
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter"
+      src="https://unpkg.com/@tensorflow/tfjs-converter@2.1.0/dist/tf-converter.js"
     ></script>
 
     <!-- Load the pre-trained models !-->
@@ -175,7 +175,7 @@
     ></script>
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow-models/handpose"
+      src="https://unpkg.com/@tensorflow-models/handpose@0.0.6/dist/handpose.js"
     ></script>
 
     <!-- Load WASM backend for tf.js !-->
@@ -187,7 +187,7 @@
     <!-- Load WebGL backend for tf.js !-->
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl"
+      src="https://unpkg.com/@tensorflow/tfjs-backend-webgl@2.1.0/dist/tf-backend-webgl.js"
     ></script>
 
     <!-- Load three.js -->

--- a/public/index.html
+++ b/public/index.html
@@ -164,11 +164,11 @@
     <!-- Load tf.js libraries !-->
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core"
+      src="https://unpkg.com/@tensorflow/tfjs-core@2.1.0/dist/tf-core.js"
     ></script>
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter"
+      src="https://unpkg.com/@tensorflow/tfjs-converter@2.1.0/dist/tf-converter.js"
     ></script>
 
     <!-- Load the pre-trained models !-->
@@ -178,7 +178,7 @@
     ></script>
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow-models/handpose"
+      src="https://unpkg.com/@tensorflow-models/handpose@0.0.6/dist/handpose.js"
     ></script>
 
     <!-- Load WASM backend for tf.js !-->
@@ -190,7 +190,7 @@
     <!-- Load WebGL backend for tf.js !-->
     <script
       crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl"
+      src="https://unpkg.com/@tensorflow/tfjs-backend-webgl@2.1.0/dist/tf-backend-webgl.js"
     ></script>
 
     <!-- Load three.js -->


### PR DESCRIPTION
This PR specifies the correct versions tags for the TF library and the models (i.e. Core, convertor, facemesh and handpose) to fix a bug that prevented the models from initiating properly. (Getting a `toFixed()` is not a function error) 

Followed [the official requirements for handpose](https://github.com/tensorflow/tfjs-models/tree/master/handpose) to point to `tf==2.1.0` version 

Also added the URL to the README as just noticed that's missing...?